### PR TITLE
Removes Tomorrow Today

### DIFF
--- a/_data/studios.yml
+++ b/_data/studios.yml
@@ -120,10 +120,6 @@
   location: "Washington, DC"
   website: threespot.com
   category: web
-
-- name: Tomorrow Today
-  location: "Cincinnati, OH"
-  website: tomorrowtoday.is
   
 - name: verynice
   location: LA / NY / ATX


### PR DESCRIPTION
Tomorrow Today appears to have ceased operations in April 2015.